### PR TITLE
fix: add protection against sending to special addresses

### DIFF
--- a/{{cookiecutter.project_name}}/contracts/Token.vy
+++ b/{{cookiecutter.project_name}}/contracts/Token.vy
@@ -144,6 +144,7 @@ def mint(receiver: address, amount: uint256) -> bool:
     {%- else %}
     assert msg.sender == self.owner "Access is denied."
     {%- endif %}
+    assert receiver not in [ZERO_ADDRESS, self]
 
     self.totalSupply += amount
     self.balanceOf[receiver] += amount

--- a/{{cookiecutter.project_name}}/contracts/Token.vy
+++ b/{{cookiecutter.project_name}}/contracts/Token.vy
@@ -82,6 +82,8 @@ def decimals() -> uint8:
 
 @external
 def transfer(receiver: address, amount: uint256) -> bool:
+    assert receiver not in [ZERO_ADDRESS, self]
+
     self.balanceOf[msg.sender] -= amount
     self.balanceOf[receiver] += amount
 
@@ -91,6 +93,8 @@ def transfer(receiver: address, amount: uint256) -> bool:
 
 @external
 def transferFrom(sender:address, receiver: address, amount: uint256) -> bool:
+    assert receiver not in [ZERO_ADDRESS, self]
+
     self.allowance[sender][msg.sender] -= amount
     self.balanceOf[sender] -= amount
     self.balanceOf[receiver] += amount


### PR DESCRIPTION
This PR adds assertions to `transfer` and `transferFrom` to protect against transfers to special addresses (0x0 and the contract's address, which are common mistakes)

fixes: #17